### PR TITLE
Make default HDMI resolution consistent with CONFIG option

### DIFF
--- a/kernel_ruikemei/drivers/video/rockchip/hdmi/rk_hdmi.h
+++ b/kernel_ruikemei/drivers/video/rockchip/hdmi/rk_hdmi.h
@@ -308,7 +308,11 @@ struct hdmi {
 #define HDMI_AUTO_CONFIG		false
 
 // HDMI default vide mode
-#define HDMI_VIDEO_DEFAULT_MODE			HDMI_1280x720p_60HZ//HDMI_1920x1080p_60HZ
+#ifdef CONFIG_BOX_FB_1080P
+   #define HDMI_VIDEO_DEFAULT_MODE			HDMI_1920x1080p_60HZ
+#else
+   #define HDMI_VIDEO_DEFAULT_MODE			HDMI_1280x720p_60HZ
+#endif
 
 // HDMI default audio parameter
 #define HDMI_AUDIO_DEFAULT_TYPE 		HDMI_AUDIO_LPCM


### PR DESCRIPTION
Problem:
Even with CONFIG_BOX_FB_1080P, the resolution stays 720p

Solution:
Override the default HDMI mode setting (720p) when .config set to 1080p
